### PR TITLE
Implemented formatting of floats when printing Expressions

### DIFF
--- a/src/pyoframe/constraints.py
+++ b/src/pyoframe/constraints.py
@@ -666,6 +666,10 @@ class Expression(ModelElement, SupportsMath):
         [1]: 3.141592653589793 x1
         [2]: 3.141592653589793 x2
         [3]: 3.141592653589793 x3
+        >>> print((x*np.pi >= 0).to_str(float_format="%0.4f"))
+        [1]: 3.1416 x1 >= 0
+        [2]: 3.1416 x2 >= 0
+        [3]: 3.1416 x3 >= 0
         """
         result = ""
         if include_header:
@@ -749,13 +753,14 @@ class Constraint(Expression):
             self._model = lhs._model
         self.sense = sense
 
-    def to_str(self, max_line_len=None, max_rows=None, var_map=None):
+    def to_str(self, max_line_len=None, max_rows=None, var_map=None, float_format=None):
         dims = self.dimensions
         str_table = self.to_str_table(
             max_line_len=max_line_len,
             max_rows=max_rows,
             include_const_term=False,
             var_map=var_map,
+            float_format=float_format
         )
         rhs = self.constant_terms.with_columns(pl.col(COEF_KEY) * -1)
         rhs = cast_coef_to_string(rhs, drop_ones=False)

--- a/src/pyoframe/constraints.py
+++ b/src/pyoframe/constraints.py
@@ -577,15 +577,11 @@ class Expression(ModelElement, SupportsMath):
         data = self.data if include_const_term else self.variable_terms
         if var_map is None:
             var_map = self._model.var_map if self._model is not None else DEFAULT_MAP
-        data = cast_coef_to_string(data)
+        data = cast_coef_to_string(data, float_format=float_format)
         data = var_map.map_vars(data)
         dimensions = self.dimensions
 
         # Create a string for each term
-        if float_format is not None:
-            data = data.with_columns(
-            pl.col(COEF_KEY).map_batches(lambda x: sprintf(x, float_format), return_dtype=str)
-            )
 
         data = (
             data
@@ -666,10 +662,9 @@ class Expression(ModelElement, SupportsMath):
         [1]: 3.141592653589793 x1
         [2]: 3.141592653589793 x2
         [3]: 3.141592653589793 x3
-        >>> print((x*np.pi >= 0).to_str(float_format="%0.4f"))
-        [1]: 3.1416 x1 >= 0
-        [2]: 3.1416 x2 >= 0
-        [3]: 3.1416 x3 >= 0
+        >>> print((np.pi*x.drop_unmatched() -  2*x.next("t") >= 0).to_str(float_format="%0.4f"))
+        [1]: 3.1416 x1 -2 x2 >= 0
+        [2]: 3.1416 x2 -2 x3 >= 0
         """
         result = ""
         if include_header:

--- a/src/pyoframe/constraints.py
+++ b/src/pyoframe/constraints.py
@@ -572,7 +572,7 @@ class Expression(ModelElement, SupportsMath):
         include_const_term=True,
         var_map=None,
         include_name=True,
-        float_format="%0.8f",
+        float_format=None,
     ):
         data = self.data if include_const_term else self.variable_terms
         if var_map is None:
@@ -582,9 +582,13 @@ class Expression(ModelElement, SupportsMath):
         dimensions = self.dimensions
 
         # Create a string for each term
+        if float_format is not None:
+            data = data.with_columns(
+            pl.col(COEF_KEY).map_batches(lambda x: sprintf(x, float_format), return_dtype=str)
+            )
+
         data = (
             data
-            .with_columns(pl.col(COEF_KEY).map_batches(lambda x: sprintf(x, float_format), return_dtype=str))
             .with_columns(
             expr=pl.concat_str(
                 COEF_KEY,
@@ -644,7 +648,7 @@ class Expression(ModelElement, SupportsMath):
         include_name=True,
         include_header=False,
         include_footer=True,
-        float_format="%0.8f",
+        float_format=None,
     ):
         """
         Examples
@@ -658,6 +662,10 @@ class Expression(ModelElement, SupportsMath):
         [1]: 3.14 x1
         [2]: 3.14 x2
         [3]: 3.14 x3
+        >>> print((x*np.pi).to_str())
+        [1]: 3.141592653589793 x1
+        [2]: 3.141592653589793 x2
+        [3]: 3.141592653589793 x3
         """
         result = ""
         if include_header:

--- a/src/pyoframe/util.py
+++ b/src/pyoframe/util.py
@@ -256,6 +256,12 @@ def sprintf(s: pl.Series, fmt: str):
     >>> s = pl.Series([1, 2, 3.4, 5.6789])
     >>> print(sprintf(s, "%0.2f").to_list())
     ['1.00', '2.00', '3.40', '5.68']
+    >>> print(sprintf(s, None).to_list())
+    ['1.0', '2.0', '3.4', '5.6789']
+    >>> sprintf(s, "oops")
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid format oops specified.
     """
 
     if fmt is None:


### PR DESCRIPTION
Usage:
```
>>> x = Variable(pl.DataFrame({"t": [1,2]})
>>> y = 1.234 * x
>>> printy.to_str(float_format="%0.1f")
[1]: 1.2 x1
[2]: 1.2 x2
```

The most important use case is when comparing the string representation of Expressions with expected representations in unit tests. 