### PR TITLE
Fixed bug related to getting solution when solver returns timeout

### DIFF
--- a/src/pyoframe/core.py
+++ b/src/pyoframe/core.py
@@ -271,7 +271,7 @@ class Set(ModelElement, SupportsMath, SupportPolarsMethodMixin):
         elif isinstance(set, Constraint):
             df = set.data.select(set.dimensions_unsafe)
         elif isinstance(set, SupportsMath):
-            df = set.to_expr().data.drop(RESERVED_COL_KEYS).unique(maintain_order=True)
+            df = set.to_expr().data.drop(RESERVED_COL_KEYS, strict=False).unique(maintain_order=True)
         elif isinstance(set, pd.Index):
             df = pl.from_pandas(pd.DataFrame(index=set).reset_index())
         elif isinstance(set, pd.DataFrame):

--- a/src/pyoframe/core.py
+++ b/src/pyoframe/core.py
@@ -1259,7 +1259,7 @@ class Variable(ModelElementWithId, SupportsMath, SupportPolarsMethodMixin):
         )
 
     def to_expr(self) -> Expression:
-        return self._new(self.data.drop(SOLUTION_KEY))
+        return self._new(self.data.drop(SOLUTION_KEY, strict=False))
 
     def _new(self, data: pl.DataFrame):
         e = Expression(data.with_columns(pl.lit(1.0).alias(COEF_KEY)))

--- a/src/pyoframe/core.py
+++ b/src/pyoframe/core.py
@@ -271,7 +271,11 @@ class Set(ModelElement, SupportsMath, SupportPolarsMethodMixin):
         elif isinstance(set, Constraint):
             df = set.data.select(set.dimensions_unsafe)
         elif isinstance(set, SupportsMath):
-            df = set.to_expr().data.drop(RESERVED_COL_KEYS, strict=False).unique(maintain_order=True)
+            df = (
+                set.to_expr()
+                .data.drop(RESERVED_COL_KEYS, strict=False)
+                .unique(maintain_order=True)
+            )
         elif isinstance(set, pd.Index):
             df = pl.from_pandas(pd.DataFrame(index=set).reset_index())
         elif isinstance(set, pd.DataFrame):

--- a/src/pyoframe/core.py
+++ b/src/pyoframe/core.py
@@ -1341,5 +1341,5 @@ class Variable(ModelElementWithId, SupportsMath, SupportPolarsMethodMixin):
         data = expr.data.rename({dim: "__prev"})
         data = data.join(
             wrapped, left_on="__prev", right_on="__next", how="inner"
-        ).drop(["__prev", "__next"])
+        ).drop(["__prev", "__next"], strict=False)
         return expr._new(data)

--- a/src/pyoframe/solvers.py
+++ b/src/pyoframe/solvers.py
@@ -313,7 +313,7 @@ class GurobiSolver(FileBasedSolver):
         termination_condition = GurobiSolver.CONDITION_MAP.get(condition, condition)
         status = Status.from_termination_condition(termination_condition)
 
-        if status.is_ok:
+        if status.is_ok and (termination_condition == "optimal"):
             if solution_file:
                 m.write(_path_to_str(solution_file))
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -92,7 +92,7 @@ def test_support_variable_attributes():
     )
     assert_frame_equal(
         m.X.RC,
-        pl.DataFrame({"t": [1, 2], "RC": [0, 1.9]}),
+        pl.DataFrame({"t": [1, 2], "RC": [0.0, 1.9]}),
         check_dtype=False,
         check_row_order=False,
     )


### PR DESCRIPTION
When the gurobi compute server reaches TimeLimit. it returns the OK flag, but may not have a solution. Fixed this by checking if termination condition is optimal before attempting to get the solution from the compute server.