### PR TITLE
Setup project to support multiple versions of polars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        polars-version: ["0.20.27", "1.12.0"]
+        python-version: ["3.9"]
+        polars-version: ["1.12.0"]
+        include:
+          - python-version: "3.8"
+            polars-version: "0.20.27"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip install --editable .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        polars-version: ["0.20.27", "1.12.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,12 +22,15 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install dependencies
-        run: pip install --editable .[dev]
+        run: |
+          pip install --editable .[dev]
+          pip install polars==${{ matrix.polars-version }}
       - name: Run tests and collect coverage
         run: pytest --cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4-beta
         with:
+          name: coverage-polars-${{ matrix.polars-version }}
           flags: smart-tests
           verbose: true
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp
 docs/reference
 dist
 *.log
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
 ]
-dependencies = ["polars>=0.20,<1.13", "numpy", "pyarrow", "pandas"]
+dependencies = ["polars>=0.20,<2", "numpy", "pyarrow", "pandas"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
 ]
-dependencies = ["polars==0.20.27", "numpy", "pyarrow", "pandas"]
+dependencies = ["polars>=0.20,<1.13", "numpy", "pyarrow", "pandas"]
 
 [project.optional-dependencies]
 dev = [

--- a/src/pyoframe/constants.py
+++ b/src/pyoframe/constants.py
@@ -6,12 +6,21 @@ Code is heavily based on the `linopy` package by Fabian Hofmann.
 MIT License
 """
 
+import importlib.metadata
+import typing
 from dataclasses import dataclass
 from enum import Enum
-import typing
 from typing import Literal, Optional, Union
-import polars as pl
 
+import polars as pl
+from packaging import version
+
+# We want to try and support multiple major versions of polars
+try:
+    POLARS_VERSION = version.parse(importlib.metadata.version("polars"))
+    print(POLARS_VERSION)
+except importlib.metadata.PackageNotFoundError:
+    POLARS_VERSION = None
 
 COEF_KEY = "__coeff"
 VAR_KEY = "__variable_id"

--- a/src/pyoframe/constants.py
+++ b/src/pyoframe/constants.py
@@ -16,10 +16,7 @@ import polars as pl
 from packaging import version
 
 # We want to try and support multiple major versions of polars
-try:
-    POLARS_VERSION = version.parse(importlib.metadata.version("polars"))
-except importlib.metadata.PackageNotFoundError:
-    POLARS_VERSION = None
+POLARS_VERSION = version.parse(importlib.metadata.version("polars"))
 
 COEF_KEY = "__coeff"
 VAR_KEY = "__variable_id"

--- a/src/pyoframe/constants.py
+++ b/src/pyoframe/constants.py
@@ -18,7 +18,6 @@ from packaging import version
 # We want to try and support multiple major versions of polars
 try:
     POLARS_VERSION = version.parse(importlib.metadata.version("polars"))
-    print(POLARS_VERSION)
 except importlib.metadata.PackageNotFoundError:
     POLARS_VERSION = None
 

--- a/src/pyoframe/core.py
+++ b/src/pyoframe/core.py
@@ -273,7 +273,7 @@ class Set(ModelElement, SupportsMath, SupportPolarsMethodMixin):
         elif isinstance(set, Constraint):
             df = set.data.select(set.dimensions_unsafe)
         elif isinstance(set, SupportsMath):
-            if POLARS_VERSION < version.parse("1"):
+            if POLARS_VERSION.major < 1:
                 df = (
                     set.to_expr()
                     .data.drop(RESERVED_COL_KEYS)
@@ -1271,7 +1271,7 @@ class Variable(ModelElementWithId, SupportsMath, SupportPolarsMethodMixin):
         )
 
     def to_expr(self) -> Expression:
-        if POLARS_VERSION < version.parse("1"):
+        if POLARS_VERSION.major < 1:
             return self._new(self.data.drop(SOLUTION_KEY))
         else:
             return self._new(self.data.drop(SOLUTION_KEY, strict=False))
@@ -1351,7 +1351,7 @@ class Variable(ModelElementWithId, SupportsMath, SupportPolarsMethodMixin):
         expr = self.to_expr()
         data = expr.data.rename({dim: "__prev"})
 
-        if POLARS_VERSION < version.parse("1"):
+        if POLARS_VERSION.major < 1:
             data = data.join(
                 wrapped, left_on="__prev", right_on="__next", how="inner"
             ).drop(["__prev", "__next"])

--- a/src/pyoframe/core.py
+++ b/src/pyoframe/core.py
@@ -614,7 +614,7 @@ class Expression(ModelElement, SupportsMath, SupportPolarsMethodMixin):
         data = (
             self.data.join(
                 multiplier,
-                on=dims_in_common,
+                on=dims_in_common if len(dims_in_common) > 0 else None,
                 how="inner" if dims_in_common else "cross",
             )
             .with_columns(pl.col(COEF_KEY) * pl.col(COEF_KEY + "_right"))


### PR DESCRIPTION
This MR simply allows any codebase which uses pyoframe to specify which version of polars they wish to use.  In our case we are trying to migrate to version 1.12, but currently use 0.20.  One thing to consider is that I don't allow the polars dependency to increase beyond the minor version 1.12.  I've seen in their release logs that they historically have introduced deprecated API calls between minor bumps which is curious.  Therefore I think with each update we'll need to refer to the polars [update guide](https://docs.pola.rs/releases/upgrade/) and determine if we can push the upper bound on the polars version.