### PR TITLE
Add dict-style component access to Model

### DIFF
--- a/src/pyoframe/_core.py
+++ b/src/pyoframe/_core.py
@@ -2071,11 +2071,11 @@ class Constraint(BaseBlock):
             return self
 
         var_name = f"{self.name}_relaxation"
-        assert not hasattr(m, var_name), (
+        assert var_name not in m, (
             "Conflicting names, relaxation variable already exists on the model."
         )
         var = Variable(self, lb=0, ub=max)
-        setattr(m, var_name, var)
+        m[var_name] = var
 
         if self.sense == ConstraintSense.LE:
             self.lhs -= var
@@ -2467,13 +2467,13 @@ class Variable(BaseOperableBlock):
         super()._on_add_to_model(model, name)
         self._assign_ids()
         if self._lb_expr is not None:
-            setattr(model, f"{name}_lb", self._lb_expr <= self)
+            model[f"{name}_lb"] = self._lb_expr <= self
 
         if self._ub_expr is not None:
-            setattr(model, f"{name}_ub", self <= self._ub_expr)
+            model[f"{name}_ub"] = self <= self._ub_expr
 
         if self._equals is not None:
-            setattr(model, f"{name}_equals", self == self._equals)
+            model[f"{name}_equals"] = self == self._equals
 
     @classmethod
     def _get_id_column_name(cls):


### PR DESCRIPTION
## Summary
- Add `m["name"] = ...` / `m["name"]` dict-style access for model components, enabling arbitrary string names (e.g. `"Variable--2 xy"`, `"con: budget ≤ 10"`)
- Unified registry via `_components` dict so attribute-assigned components are also accessible via `m["X"]` and vice versa
- Add `__contains__` support (`"X" in m`)

## Changes
**`src/pyoframe/_model.py`** — Extract `_register_component()` as single chokepoint for component registration. Add `__setitem__`, `__getitem__`, `__contains__`. Refactor `__setattr__` to delegate to `_register_component`.

**`src/pyoframe/_core.py`** — Replace `setattr(model, ...)` / `hasattr(m, ...)` calls in `Variable._on_add_to_model` and `Constraint.relax` with dict-style access (`model[name] = ...` / `name not in m`).

**`tests/test_names.py`** — 8 new tests: non-identifier names, unified attr↔dict access, `__contains__`, expression bounds with non-identifier names, error cases (reserved name, duplicate, invalid type, missing key), and end-to-end solve.

## Test plan
- [x] All existing tests pass (146 passed, 2 skipped due to missing ipopt/copt)
- [x] New `test_names.py` tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)