### PR TITLE
Accelerate string conversion by 2x

### DIFF
--- a/src/pyoframe/_core.py
+++ b/src/pyoframe/_core.py
@@ -1439,7 +1439,7 @@ class Expression(BaseOperableBlock):
         str_col_name: str = "expression",
         include_const_term: bool = True,
         return_df: Literal[False] = False,
-        compute_all_rows: bool = True,
+        _compute_all_rows: bool = True,
     ) -> str: ...
 
     @overload
@@ -1448,7 +1448,7 @@ class Expression(BaseOperableBlock):
         str_col_name: str = "expression",
         include_const_term: bool = True,
         return_df: Literal[True] = True,
-        compute_all_rows: bool = True,
+        _compute_all_rows: bool = True,
     ) -> pl.DataFrame: ...
 
     def to_str(
@@ -1456,7 +1456,7 @@ class Expression(BaseOperableBlock):
         str_col_name: str = "expression",
         include_const_term: bool = True,
         return_df: bool = False,
-        compute_all_rows: bool = True,
+        _compute_all_rows: bool = True,
     ) -> str | pl.DataFrame:
         """Converts the expression to a human-readable string, or several arranged in a table.
 
@@ -1471,9 +1471,9 @@ class Expression(BaseOperableBlock):
                 If `False`, constant terms are omitted from the string representation.
             return_df:
                 If `True`, returns a DataFrame containing the human-readable strings instead of the DataFrame's string representation.
-            compute_all_rows:
-                If specified, only the first `n/2` and last `n/2` rows are included in the returned DataFrame, where `n` is determined according to the Polars setting ([`Config.print_polars_config`][pyoframe._Config.print_polars_config]).
-                This parameter is used internally to accelerate computations. When `return_df` is `False` it is overridden to `False` since only the first `n/2` and last `n/2` rows are needed to generate the string representation.
+            _compute_all_rows:
+                If `False` and `return_df` is True, only a subset of rows are included in the returned DataFrame. This option is used internally to accelerate conversions
+                that will be truncated anyways. This option may change in future versions of pyoframe.
 
         Examples:
             >>> import polars as pl
@@ -1537,7 +1537,7 @@ class Expression(BaseOperableBlock):
             if truncate:
                 data = data.head(Config.print_max_terms)
         else:
-            if not return_df or not compute_all_rows:
+            if not return_df or not _compute_all_rows:
                 # The default for polars is 10. See https://github.com/pola-rs/polars/blob/507e4fc79c0c78162ab34d17c0499ec03850b0cc/crates/polars-core/src/fmt.rs#L32-L34
                 n = Config.print_polars_config.state(if_set=True).get(
                     "POLARS_FMT_MAX_ROWS", 10
@@ -2281,7 +2281,7 @@ class Constraint(BaseBlock):
             include_const_term=False,
             return_df=True,
             str_col_name="constraint",
-            compute_all_rows=return_df,
+            _compute_all_rows=return_df,
         )
         rhs = self.lhs.constant_terms.with_columns(pl.col(COEF_KEY) * -1)
         rhs = cast_coef_to_string(rhs, drop_ones=False, always_show_sign=False)

--- a/src/pyoframe/_core.py
+++ b/src/pyoframe/_core.py
@@ -1439,6 +1439,7 @@ class Expression(BaseOperableBlock):
         str_col_name: str = "expression",
         include_const_term: bool = True,
         return_df: Literal[False] = False,
+        compute_all_rows: bool = True,
     ) -> str: ...
 
     @overload
@@ -1447,6 +1448,7 @@ class Expression(BaseOperableBlock):
         str_col_name: str = "expression",
         include_const_term: bool = True,
         return_df: Literal[True] = True,
+        compute_all_rows: bool = True,
     ) -> pl.DataFrame: ...
 
     def to_str(
@@ -1454,6 +1456,7 @@ class Expression(BaseOperableBlock):
         str_col_name: str = "expression",
         include_const_term: bool = True,
         return_df: bool = False,
+        compute_all_rows: bool = True,
     ) -> str | pl.DataFrame:
         """Converts the expression to a human-readable string, or several arranged in a table.
 
@@ -1468,6 +1471,9 @@ class Expression(BaseOperableBlock):
                 If `False`, constant terms are omitted from the string representation.
             return_df:
                 If `True`, returns a DataFrame containing the human-readable strings instead of the DataFrame's string representation.
+            compute_all_rows:
+                If specified, only the first `n/2` and last `n/2` rows are included in the returned DataFrame, where `n` is determined according to the Polars setting ([`Config.print_polars_config`][pyoframe._Config.print_polars_config]).
+                This parameter is used internally to accelerate computations. When `return_df` is `False` it is overridden to `False` since only the first `n/2` and last `n/2` rows are needed to generate the string representation.
 
         Examples:
             >>> import polars as pl
@@ -1521,8 +1527,47 @@ class Expression(BaseOperableBlock):
             3000000 +2 V[0,0] * V[0,0] +2 V[0,1] * V[0,1] +2 V[0,2] * V[0,2] +2 V[0,3] * V[0,3] …
 
         """
-        # TODO consider optimizing using LazyFrames since .head() could maybe be automatically pushed up the chain of operations.
         data = self.data if include_const_term else self.variable_terms
+
+        dimensions = self.dimensions
+
+        # Truncate data to speed up string conversion by ~2x
+        if dimensions is None:
+            truncate = data.height > Config.print_max_terms
+            if truncate:
+                data = data.head(Config.print_max_terms)
+        else:
+            if not return_df or not compute_all_rows:
+                # The default for polars is 10. See https://github.com/pola-rs/polars/blob/507e4fc79c0c78162ab34d17c0499ec03850b0cc/crates/polars-core/src/fmt.rs#L32-L34
+                n = Config.print_polars_config.state(if_set=True).get(
+                    "POLARS_FMT_MAX_ROWS", 10
+                )
+                # Add 1 to get ellipses
+                n = int(n) + 1  # type: ignore
+
+                group_number = (
+                    data.select(dimensions)
+                    .unique(maintain_order=Config.maintain_order)
+                    .with_row_index("__group_index")
+                )
+
+                first_exclude = n // 2 + (1 if n % 2 == 1 else 0)
+                last_exclude = group_number.height - n // 2 - 1
+
+                data = data.join(
+                    group_number,
+                    on=dimensions,
+                    maintain_order="left" if Config.maintain_order else None,
+                )
+                data = data.filter(
+                    ~pl.col("__group_index").is_between(first_exclude, last_exclude)
+                ).drop("__group_index")
+
+            truncate = data.group_by(
+                dimensions, maintain_order=Config.maintain_order
+            ).agg(__truncated=pl.len() > Config.print_max_terms)
+            data = data.filter(pl.row_index().over(dimensions) < Config.print_max_terms)
+
         data = cast_coef_to_string(data)
 
         for var_col in self._variable_columns:
@@ -1549,8 +1594,6 @@ class Expression(BaseOperableBlock):
                 .alias(VAR_KEY)
             ).drop(QUAD_VAR_KEY)
 
-        dimensions = self.dimensions
-
         # Create a string for each term
         data = data.with_columns(
             pl.concat_str(
@@ -1562,28 +1605,31 @@ class Expression(BaseOperableBlock):
             .alias(str_col_name)
         ).drop(COEF_KEY, VAR_KEY)
 
-        if dimensions is not None:
-            data = data.group_by(dimensions, maintain_order=Config.maintain_order).agg(
-                pl.concat_str(
-                    pl.col(str_col_name)
-                    .head(Config.print_max_terms)
-                    .str.join(delimiter=" "),
-                    pl.when(pl.len() > Config.print_max_terms)
-                    .then(pl.lit(" …"))
-                    .otherwise(pl.lit("")),
-                )
-            )
-        else:
-            truncate = data.height > Config.print_max_terms
-            if truncate:
-                data = data.head(Config.print_max_terms)
-
+        if dimensions is None:
             data = data.select(pl.col(str_col_name).str.join(delimiter=" "))
 
-            if truncate:
+            if truncate:  # type: ignore
                 data = data.with_columns(
                     pl.concat_str(pl.col(str_col_name), pl.lit(" …"))
                 )
+        else:
+            data = data.group_by(dimensions, maintain_order=Config.maintain_order).agg(
+                pl.concat_str(
+                    pl.col(str_col_name).str.join(delimiter=" "),
+                )
+            )
+
+            data = data.join(
+                truncate,  # type: ignore
+                on=dimensions,
+                maintain_order="left" if Config.maintain_order else None,
+            )
+            data = data.with_columns(
+                pl.concat_str(
+                    pl.col(str_col_name),
+                    pl.when("__truncated").then(pl.lit(" …")).otherwise(pl.lit("")),
+                )
+            ).drop("__truncated")
 
         # Remove leading +
         data = data.with_columns(pl.col(str_col_name).str.strip_chars(characters="  +"))
@@ -2232,7 +2278,10 @@ class Constraint(BaseBlock):
         """
         dims = self.dimensions
         str_table = self.lhs.to_str(
-            include_const_term=False, return_df=True, str_col_name="constraint"
+            include_const_term=False,
+            return_df=True,
+            str_col_name="constraint",
+            compute_all_rows=return_df,
         )
         rhs = self.lhs.constant_terms.with_columns(pl.col(COEF_KEY) * -1)
         rhs = cast_coef_to_string(rhs, drop_ones=False, always_show_sign=False)


### PR DESCRIPTION
Fixes #229 

Outputs of this code are twice as low now:

```python
import timeit
import pyoframe as pf

m = pf.Model()

m.X = pf.Variable(pf.Set(x=range(100), y=range(100), z=range(100), a=range(10)))

expr = m.X.sum("x", "y")

t = timeit.Timer(stmt="repr(expr)", globals=globals()).repeat(repeat=5, number=1)
print(f"Time taken: {[f'{x:.3f}' for x in t]} seconds")

```